### PR TITLE
mac fixes

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -5,7 +5,8 @@ INCLUDEPATH += src src/json src/cryptopp src/qt
 
 # for boost 1.37, add -mt to the boost libraries
 unix:LIBS += -lssl -lcrypto -lboost_system -lboost_filesystem -lboost_program_options -lboost_thread -ldb_cxx
-macx:DEFINES += __WXMAC_OSX__ MSG_NOSIGNAL=0
+macx:DEFINES += __WXMAC_OSX__ MSG_NOSIGNAL=0 BOOST_FILESYSTEM_VERSION=3
+macx:LIBS += -lboost_thread-mt
 
 # disable quite some warnings because bitcoin core "sins" a lot
 QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wno-invalid-offsetof -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare -Wno-char-subscripts  -Wno-unused-value -Wno-sequence-point -Wno-parentheses -Wno-unknown-pragmas -Wno-switch

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 using namespace std;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -7,6 +7,7 @@
 #include "net.h"
 #include "init.h"
 #include "strlcpy.h"
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "net.h"
 #include "init.h"
 #include "cryptopp/sha.h"
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 using namespace std;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,7 @@
 #include "strlcpy.h"
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>


### PR DESCRIPTION
Here are my changes for building (with qmake) on mac. The qmake command I've been using is:

qmake -spec macx-g++ INCLUDEPATH+=/opt/local/include INCLUDEPATH+=/opt/local/include/db51 QMAKE_LIBDIR=/opt/local/lib QMAKE_LIBDIR+=/opt/local/lib/db51

This is using libraries installed with MacPorts.

cheers,
-Mark
