### PR TITLE
fix error when cancelling export

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -187,6 +187,8 @@ void AddressBookPage::exportClicked()
             QDir::currentPath(),
             tr("Comma separated file (*.csv)"));
 
+    if (filename.isNull()) return;
+
     CSVModelWriter writer(filename);
 
     // name, column, role

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -242,6 +242,8 @@ void TransactionView::exportClicked()
             QDir::currentPath(),
             tr("Comma separated file (*.csv)"));
 
+    if (filename.isNull()) return;
+
     CSVModelWriter writer(filename);
 
     // name, column, role


### PR DESCRIPTION
When no filename is given for export, and the export is canceled instead, the client should do nothing. In the current version it is returning an error. This update fixes that error.
