### PR TITLE
Send Coins page changes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -525,7 +525,9 @@ void BitcoinGUI::gotoSendCoinsPage()
     if(centralWidget->currentWidget() != sendCoinsPage)
     {
         // Clear the current contents if we arrived from another tab
-        sendCoinsPage->clear();
+        // Not necessary especially if the user is jumping between Transactions
+        // and Send Coins pages. - Matoking
+        //sendCoinsPage->clear();
     }
     centralWidget->setCurrentWidget(sendCoinsPage);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -522,13 +522,6 @@ void BitcoinGUI::gotoReceiveCoinsPage()
 void BitcoinGUI::gotoSendCoinsPage()
 {
     sendCoinsAction->setChecked(true);
-    if(centralWidget->currentWidget() != sendCoinsPage)
-    {
-        // Clear the current contents if we arrived from another tab
-        // Not necessary especially if the user is jumping between Transactions
-        // and Send Coins pages. - Matoking
-        //sendCoinsPage->clear();
-    }
     centralWidget->setCurrentWidget(sendCoinsPage);
 
     exportAction->setEnabled(false);

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -25,7 +25,7 @@
         <x>0</x>
         <y>0</y>
         <width>666</width>
-        <height>162</height>
+        <height>165</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -59,7 +59,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
-      <number>12</number>
+      <number>6</number>
      </property>
      <item>
       <widget class="QPushButton" name="addButton">
@@ -72,6 +72,26 @@
        <property name="icon">
         <iconset resource="../bitcoin.qrc">
          <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Clear all</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+       <property name="autoRepeatDelay">
+        <number>300</number>
        </property>
       </widget>
      </item>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -22,6 +22,7 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     addEntry();
 
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
+    connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)


### PR DESCRIPTION
Send Coins page not cleared when changing tabs. 
Added a Clear all button for clearing the entries.

Reason for this is because clearing the transactions when changing tabs doesn't make sense, especially if the user is jumping between Transactions and Send Coins pages. (checking who to send to and how much)

There is also a Clear all button for clearing all the to-be-sent transactions.
